### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,8 @@
 # Based on https://github.com/mvdan/github-actions-golang
 on: [push, pull_request, workflow_dispatch]
 name: Tests
+permissions:
+  contents: read
 jobs:
   test:
     name: Run tests


### PR DESCRIPTION
Potential fix for [https://github.com/qba73/fox/security/code-scanning/3](https://github.com/qba73/fox/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow file. This block should specify the least privileges required for each job. Since the jobs in this workflow primarily perform read-only operations, the `contents: read` permission is sufficient. 

The `permissions` block can be added at the root level of the workflow to apply to all jobs, or it can be added individually to each job. In this case, adding it at the root level is more efficient and ensures consistency across all jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
